### PR TITLE
chore: bump to v1.0.1 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
-This version is compatible with Vercel AI SDK v5-beta. For v4 compatibility, please use version 0.x.x.
+This version is compatible with Vercel AI SDK v5. For v4 compatibility, please use version 0.x.x.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img src="https://img.shields.io/badge/status-beta-FF6700" alt="beta status">
-  <a href="https://www.npmjs.com/package/ai-sdk-provider-gemini-cli"><img src="https://img.shields.io/npm/v/ai-sdk-provider-gemini-cli/beta?color=00A79E" alt="npm beta version" /></a>
+  <img src="https://img.shields.io/badge/status-stable-00A79E" alt="stable status">
+  <a href="https://www.npmjs.com/package/ai-sdk-provider-gemini-cli"><img src="https://img.shields.io/npm/v/ai-sdk-provider-gemini-cli?color=00A79E" alt="npm stable version" /></a>
   <a href="https://www.npmjs.com/package/ai-sdk-provider-gemini-cli"><img src="https://img.shields.io/npm/unpacked-size/ai-sdk-provider-gemini-cli?color=00A79E" alt="install size" /></a>
   <a href="https://www.npmjs.com/package/ai-sdk-provider-gemini-cli"><img src="https://img.shields.io/npm/dy/ai-sdk-provider-gemini-cli.svg?color=00A79E" alt="npm downloads" /></a>
   <a href="https://nodejs.org/en/about/releases/"><img src="https://img.shields.io/badge/node-%3E%3D18-00A79E" alt="Node.js ≥ 18" /></a>
@@ -9,29 +9,29 @@
 
 # AI SDK Provider for Gemini CLI
 
-> **Beta Release**: This is the v5-beta compatible version. For AI SDK v4 support, use version 0.x.
+> **Stable Release**: This version is compatible with AI SDK v5. For AI SDK v4 support, use version 0.x.
 
 A community provider for the [Vercel AI SDK](https://sdk.vercel.ai/docs) that enables using Google's Gemini models through the [@google/gemini-cli-core](https://www.npmjs.com/package/@google/gemini-cli-core) library and Google Cloud Code endpoints.
 
 ## Version Compatibility
 
-| Provider Version | AI SDK Version | Status | Branch                                                                                 |
-| ---------------- | -------------- | ------ | -------------------------------------------------------------------------------------- |
-| 0.x              | v4             | Stable | [`ai-sdk-v4`](https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/tree/ai-sdk-v4) |
-| 1.x-beta         | v5-beta        | Beta   | `main`                                                                                 |
+| Provider Version | AI SDK Version | NPM Tag     | Status | Branch                                                                                 |
+| ---------------- | -------------- | ----------- | ------ | -------------------------------------------------------------------------------------- |
+| 1.x              | v5             | `latest`    | Stable | `main`                                                                                 |
+| 0.x              | v4             | `ai-sdk-v4` | Stable | [`ai-sdk-v4`](https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/tree/ai-sdk-v4) |
 
 ### Installing the Right Version
 
-**For AI SDK v4 (stable):**
+**For AI SDK v5 (current, default):**
 
 ```bash
-npm install ai-sdk-provider-gemini-cli@^0.1.1 ai@^4.3.16
+npm install ai-sdk-provider-gemini-cli ai
 ```
 
-**For AI SDK v5-beta:**
+**For AI SDK v4 (legacy):**
 
 ```bash
-npm install ai-sdk-provider-gemini-cli@beta ai@beta
+npm install ai-sdk-provider-gemini-cli@ai-sdk-v4 ai@^4.3.16
 ```
 
 ## Disclaimer
@@ -46,7 +46,7 @@ Please ensure you have appropriate permissions and comply with all applicable te
 
 ## Features
 
-- 🚀 Compatible with Vercel AI SDK (v4 and v5-beta)
+- 🚀 Compatible with Vercel AI SDK (v4 and v5)
 - ☁️ Uses Google Cloud Code endpoints (https://cloudcode-pa.googleapis.com)
 - 🔄 Streaming support for real-time responses
 - 🛠️ Tool/function calling capabilities
@@ -67,16 +67,16 @@ gemini  # Follow the interactive authentication setup
 ### 2. Add the provider
 
 ```bash
-# For v5-beta
-npm install ai-sdk-provider-gemini-cli@beta ai@beta
+# For AI SDK v5 (current, default)
+npm install ai-sdk-provider-gemini-cli ai
 
-# For v4 (stable)
-npm install ai-sdk-provider-gemini-cli@^0.1.1 ai@^4.3.16
+# For AI SDK v4 (legacy)
+npm install ai-sdk-provider-gemini-cli@ai-sdk-v4 ai@^4.3.16
 ```
 
 ## Quick Start
 
-### AI SDK v5-beta
+### AI SDK v5
 
 ```typescript
 import { generateText } from 'ai';
@@ -113,13 +113,13 @@ const { text } = await generateText({
 console.log(text);
 ```
 
-## Breaking Changes in v1.x-beta
+## Breaking Changes in v1.x
 
-See [CHANGELOG.md](CHANGELOG.md) for details on migrating from v0.x to v1.x-beta.
+See [CHANGELOG.md](CHANGELOG.md) for details on migrating from v0.x to v1.x.
 
 Key changes:
 
-- Requires AI SDK v5-beta
+- Requires AI SDK v5
 - New response format with content arrays
 - Updated parameter names (maxTokens → maxOutputTokens)
 - New streaming API patterns
@@ -130,7 +130,7 @@ Key changes:
 - **[Examples](examples/)** - Comprehensive examples demonstrating all features
 - **[API Reference](docs/)** - Technical documentation and implementation details
 - **[Authentication Guide](docs/gemini-cli-auth-options.md)** - Detailed authentication options
-- **[Migration Guide](CHANGELOG.md)** - v0.x to v1.x-beta migration guide
+- **[Migration Guide](CHANGELOG.md)** - v0.x to v1.x migration guide
 
 ## Examples
 
@@ -217,7 +217,7 @@ export GEMINI_API_KEY="your-api-key-here"
 
 ### Text Generation
 
-**AI SDK v5-beta:**
+\*\*AI SDK v5:
 
 ```typescript
 import { generateText } from 'ai';
@@ -265,7 +265,7 @@ const result = await streamText({
   prompt: 'Write a story about a robot learning to paint',
 });
 
-// v5-beta: Access text stream
+// v5: Access text stream
 for await (const chunk of result.textStream) {
   process.stdout.write(chunk);
 }
@@ -299,7 +299,7 @@ console.log(result.object);
 
 ### System Messages
 
-**AI SDK v5-beta:**
+\*\*AI SDK v5:
 
 ```typescript
 import { generateText } from 'ai';
@@ -332,7 +332,7 @@ console.log(text);
 
 ### Conversation History
 
-**AI SDK v5-beta:**
+\*\*AI SDK v5:
 
 ```typescript
 const result = await generateText({
@@ -373,7 +373,7 @@ console.log(text); // Should mention "Alice"
 
 ### Model Settings
 
-**AI SDK v5-beta:**
+\*\*AI SDK v5:
 
 ```typescript
 const model = gemini('gemini-2.5-pro', {

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,13 @@
 
 This directory contains technical documentation for the AI SDK Provider for Gemini CLI implementation.
 
-## AI SDK v5-beta Documentation
+## AI SDK v5 Documentation
 
-This provider is compatible with Vercel AI SDK v5-beta. For v5-specific documentation, see:
+This provider is compatible with Vercel AI SDK v5. For v5-specific documentation, see:
 
-- **[ai-sdk-v5/GUIDE.md](ai-sdk-v5/GUIDE.md)** - Comprehensive usage guide for v5-beta
+- **[ai-sdk-v5/GUIDE.md](ai-sdk-v5/GUIDE.md)** - Comprehensive usage guide for v5
 - **[ai-sdk-v5/BREAKING_CHANGES.md](ai-sdk-v5/BREAKING_CHANGES.md)** - Breaking changes and migration guide from v4
-- **[ai-sdk-v5/TROUBLESHOOTING.md](ai-sdk-v5/TROUBLESHOOTING.md)** - Common issues and solutions for v5-beta
+- **[ai-sdk-v5/TROUBLESHOOTING.md](ai-sdk-v5/TROUBLESHOOTING.md)** - Common issues and solutions for v5
 
 ## Documentation Overview
 
@@ -22,7 +22,7 @@ Comprehensive guide to the three authentication methods supported by `@google/ge
 - Vertex AI (`vertex-ai`)
 
 ### 3. [Language Model V2 Implementation](./language-model-v2-implementation.md)
-Detailed specification of the Vercel AI SDK Language Model V2 interface implementation for v5-beta:
+Detailed specification of the Vercel AI SDK Language Model V2 interface implementation for v5:
 - Core interfaces and types
 - Message format specifications
 - Tool calling interfaces
@@ -77,6 +77,6 @@ The provider implements a direct integration with Google's Cloud Code endpoints 
 - Native OAuth support with cached credentials
 - Direct access to Gemini models
 - Optimal performance without intermediate layers
-- Full compatibility with Vercel AI SDK v5-beta patterns
+- Full compatibility with Vercel AI SDK v5 patterns
 
 For implementation examples, see the [examples directory](../examples/).

--- a/docs/ai-sdk-v5/BREAKING_CHANGES.md
+++ b/docs/ai-sdk-v5/BREAKING_CHANGES.md
@@ -1,10 +1,10 @@
-# Breaking Changes: AI SDK v5-beta
+# Breaking Changes: AI SDK v5
 
-This document outlines the breaking changes when migrating from AI SDK v4 to v5-beta for the Gemini CLI provider.
+This document outlines the breaking changes when migrating from AI SDK v4 to v5 for the Gemini CLI provider.
 
 ## Overview
 
-The Vercel AI SDK v5-beta introduces significant architectural changes that affect how providers are implemented and used. This provider has been updated to be fully compatible with v5-beta.
+The Vercel AI SDK v5 introduces significant architectural changes that affect how providers are implemented and used. This provider has been updated to be fully compatible with v5.
 
 ## Key Breaking Changes
 
@@ -18,7 +18,7 @@ const { text, usage } = await generateText({
 });
 ```
 
-**v5-beta Response:**
+**v5 Response:**
 ```typescript
 const result = await generateText({
   model: gemini('gemini-2.5-pro'),
@@ -33,9 +33,9 @@ console.log(result.content[0].text); // Alternative access
 
 ### 2. Parameter Name Changes
 
-Several parameter names have been updated to align with v5-beta conventions:
+Several parameter names have been updated to align with v5 conventions:
 
-| v4 Parameter | v5-beta Parameter | Notes |
+| v4 Parameter | v5 Parameter | Notes |
 |--------------|-------------------|-------|
 | `maxTokens` | `maxOutputTokens` | Maximum tokens to generate |
 | `stopWords` | `stopSequences` | Sequences that stop generation |
@@ -54,7 +54,7 @@ for await (const chunk of textStream) {
 }
 ```
 
-**v5-beta Streaming:**
+**v5 Streaming:**
 ```typescript
 const result = await streamText({
   model: gemini('gemini-2.5-pro'),
@@ -83,7 +83,7 @@ Token usage reporting has been standardized:
 }
 ```
 
-**v5-beta:**
+**v5:**
 ```typescript
 {
   inputTokens: 10,
@@ -94,7 +94,7 @@ Token usage reporting has been standardized:
 
 ### 5. Message Format Requirements
 
-v5-beta enforces stricter message formats:
+v5 enforces stricter message formats:
 
 ```typescript
 // Messages must have proper role types
@@ -214,6 +214,6 @@ npm run example:test
 
 ## Need Help?
 
-- Check the [examples](../../examples/) directory for v5-beta usage patterns
+- Check the [examples](../../examples/) directory for v5 usage patterns
 - Review the [GUIDE.md](./GUIDE.md) for detailed usage instructions
 - See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for common issues

--- a/docs/ai-sdk-v5/DEVELOPMENT_STATUS.md
+++ b/docs/ai-sdk-v5/DEVELOPMENT_STATUS.md
@@ -1,19 +1,19 @@
-# Development Status for AI SDK v5-beta
+# Development Status for AI SDK v5
 
 ## Overview
 
-This document tracks the development status of the Gemini CLI Provider for Vercel AI SDK v5-beta compatibility.
+This document tracks the development status of the Gemini CLI Provider for Vercel AI SDK v5 compatibility.
 
 ## Current Status: ✅ COMPLETE
 
-The provider has been fully migrated to support AI SDK v5-beta.
+The provider has been fully migrated to support AI SDK v5.
 
 ## Completed Features
 
 ### Core Functionality
 - ✅ **Provider Interface**: Extends `ProviderV2` correctly
 - ✅ **Language Model**: Implements `LanguageModelV2` interface
-- ✅ **Text Generation**: Full `generateText` support with v5-beta response format
+- ✅ **Text Generation**: Full `generateText` support with v5 response format
 - ✅ **Streaming**: Complete `streamText` implementation with promise-based API
 - ✅ **Object Generation**: `generateObject` with Zod schema validation
 - ✅ **System Messages**: Proper system instruction support
@@ -30,18 +30,18 @@ The provider has been fully migrated to support AI SDK v5-beta.
 - ✅ **gemini-2.5-flash**: Full support for faster responses
 
 ### Error Handling
-- ✅ **Error Mapping**: Proper error types for v5-beta
+- ✅ **Error Mapping**: Proper error types for v5
 - ✅ **Abort Signals**: Correct AbortError handling (with limitations)
 - ✅ **Validation Errors**: Clear error messages for schema failures
 
 ### Documentation
 - ✅ **Breaking Changes Guide**: Complete migration guide from v4
-- ✅ **Usage Guide**: Comprehensive v5-beta patterns and examples
+- ✅ **Usage Guide**: Comprehensive v5 patterns and examples
 - ✅ **Troubleshooting**: Common issues and solutions documented
 - ✅ **API Documentation**: All interfaces documented
 
 ### Examples
-- ✅ All 14 example files updated and tested with v5-beta
+- ✅ All 14 example files updated and tested with v5
 - ✅ Examples use gemini-2.5-pro for consistency
 - ✅ Clear documentation of patterns and best practices
 
@@ -74,7 +74,7 @@ The provider has been fully migrated to support AI SDK v5-beta.
 ## Testing Status
 
 ### Unit Tests
-- ✅ All tests updated for v5-beta compatibility
+- ✅ All tests updated for v5 compatibility
 - ✅ 98.85% test coverage achieved
 - ✅ All tests passing
 
@@ -94,7 +94,7 @@ The provider has been fully migrated to support AI SDK v5-beta.
 
 ## Migration Checklist
 
-- [x] Update dependencies to v5-beta versions
+- [x] Update dependencies to v5 versions
 - [x] Implement ProviderV2 interface
 - [x] Implement LanguageModelV2 interface
 - [x] Update message format handling

--- a/docs/ai-sdk-v5/GUIDE.md
+++ b/docs/ai-sdk-v5/GUIDE.md
@@ -1,6 +1,6 @@
-# Gemini CLI Provider for AI SDK v5-beta Guide
+# Gemini CLI Provider for AI SDK v5 Guide
 
-This guide covers how to use the Gemini CLI Provider with Vercel AI SDK v5-beta.
+This guide covers how to use the Gemini CLI Provider with Vercel AI SDK v5.
 
 ## Table of Contents
 

--- a/docs/ai-sdk-v5/TROUBLESHOOTING.md
+++ b/docs/ai-sdk-v5/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
-# Troubleshooting Guide for AI SDK v5-beta
+# Troubleshooting Guide for AI SDK v5
 
-This guide helps resolve common issues when using the Gemini CLI Provider with AI SDK v5-beta.
+This guide helps resolve common issues when using the Gemini CLI Provider with AI SDK v5.
 
 ## Common Issues
 
@@ -134,17 +134,17 @@ try {
 
 ### 5. TypeScript Type Errors
 
-**Problem**: Getting type errors after upgrading to v5-beta.
+**Problem**: Getting type errors after upgrading to v5.
 
 ```typescript
 // Type error: Property 'promptTokens' does not exist
 console.log(result.usage.promptTokens);
 ```
 
-**Solution**: Update to v5-beta property names:
+**Solution**: Update to v5 property names:
 
 ```typescript
-// v4 → v5-beta mapping
+// v4 → v5 mapping
 console.log(result.usage.inputTokens);   // was promptTokens
 console.log(result.usage.outputTokens);  // was completionTokens
 console.log(result.text);                // was result (destructured)
@@ -162,10 +162,10 @@ const { textStream } = await streamText({
 });
 ```
 
-**Solution**: v5-beta returns a promise with stream properties:
+**Solution**: v5 returns a promise with stream properties:
 
 ```typescript
-// Correct v5-beta pattern
+// Correct v5 pattern
 const result = await streamText({
   model: gemini('gemini-2.5-pro'),
   prompt: 'Tell a story',
@@ -308,7 +308,7 @@ npm list ai-sdk-provider-gemini-cli
 ### 3. Verify AI SDK Version
 
 ```bash
-# Ensure AI SDK is v5-beta
+# Ensure AI SDK is v5
 npm list ai
 # Should show: ai@5.x.x-beta.x
 ```

--- a/docs/language-model-v2-implementation.md
+++ b/docs/language-model-v2-implementation.md
@@ -1,14 +1,14 @@
-# LanguageModelV2 Implementation Summary for AI SDK v5-beta
+# LanguageModelV2 Implementation Summary for AI SDK v5
 
 ## Overview
 
-The `doGenerate` and `doStream` methods are the core generation methods that all Language Model V2 providers must implement for AI SDK v5-beta compatibility. These methods handle standardized prompts and options, call the underlying model API, and return standardized results.
+The `doGenerate` and `doStream` methods are the core generation methods that all Language Model V2 providers must implement for AI SDK v5 compatibility. These methods handle standardized prompts and options, call the underlying model API, and return standardized results.
 
 ## Key Interfaces and Types
 
 ### 1. LanguageModelV2 Interface
 
-The main interface that providers must implement for v5-beta:
+The main interface that providers must implement for v5:
 
 ```typescript
 export type LanguageModelV2 = {
@@ -45,7 +45,7 @@ export type LanguageModelV2 = {
 
 ### 2. LanguageModelV2CallOptions
 
-The options passed to doGenerate and doStream in v5-beta:
+The options passed to doGenerate and doStream in v5:
 
 ```typescript
 export type LanguageModelV1CallOptions = LanguageModelV1CallSettings & {

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -7,7 +7,7 @@ ai-sdk-provider-gemini-cli/
 ├── src/                                      # Source code
 │   ├── index.ts                              # Main exports
 │   ├── gemini-provider.ts                    # Provider factory function
-│   ├── gemini-language-model.ts              # Core LanguageModelV2 implementation (v5-beta)
+│   ├── gemini-language-model.ts              # Core LanguageModelV2 implementation (v5)
 │   ├── client.ts                             # Gemini CLI Core client initialization
 │   ├── message-mapper.ts                     # Maps AI SDK messages to Gemini format
 │   ├── tool-mapper.ts                        # Maps AI SDK tools to Gemini format
@@ -50,7 +50,7 @@ ai-sdk-provider-gemini-cli/
 │   ├── language-model-v2-implementation.md   # AI SDK v5 interface
 │   ├── tool-schema-mapping.md                # Tool schema conversion
 │   ├── zod-to-gemini-mapping.md              # Zod to Gemini mapping
-│   └── ai-sdk-v5/                            # v5-beta specific docs
+│   └── ai-sdk-v5/                            # v5 specific docs
 │       ├── BREAKING_CHANGES.md               # Migration guide from v4
 │       ├── DEVELOPMENT_STATUS.md             # Current development status
 │       ├── GUIDE.md                          # Comprehensive usage guide
@@ -89,7 +89,7 @@ ai-sdk-provider-gemini-cli/
   - `gemini-provider.ts` - Factory function for creating providers
 
 - **Language Model**
-  - `gemini-language-model.ts` - Implements Vercel AI SDK's LanguageModelV2 interface for v5-beta
+  - `gemini-language-model.ts` - Implements Vercel AI SDK's LanguageModelV2 interface for v5
   - Handles both streaming and non-streaming generation
   - Manages authentication and client initialization
   - Supports abort signals (with limitations)
@@ -131,7 +131,7 @@ Technical documentation covering:
 - **Minimal Dependencies**: Only essential packages included
 - **Direct Integration**: Uses Gemini CLI Core directly without abstraction layers
 - **Type Safety**: Full TypeScript support with comprehensive types
-- **AI SDK Compatibility**: Implements standard LanguageModelV2 interface for v5-beta
+- **AI SDK Compatibility**: Implements standard LanguageModelV2 interface for v5
 - **OAuth First**: Designed for OAuth authentication via Gemini CLI
 
 ## Test Coverage

--- a/docs/tool-schema-mapping.md
+++ b/docs/tool-schema-mapping.md
@@ -4,12 +4,12 @@
 
 This document outlines the mapping between Vercel AI SDK's Zod-based tool schemas and Google Gemini's FunctionDeclaration format.
 
-**Note**: This mapping applies to both AI SDK v4 and v5-beta. The tool schema format remains consistent across versions.
+**Note**: This mapping applies to both AI SDK v4 and v5. The tool schema format remains consistent across versions.
 
 ## Vercel AI SDK Tool Structure
 
 ```typescript
-// Note: In v5-beta, this is LanguageModelV2FunctionTool
+// Note: In v5, this is LanguageModelV2FunctionTool
 // but the structure remains the same
 interface LanguageModelV1FunctionTool {
   type: 'function';

--- a/docs/zod-to-gemini-mapping.md
+++ b/docs/zod-to-gemini-mapping.md
@@ -4,7 +4,7 @@
 
 This document provides a comprehensive mapping between Vercel AI SDK's use of Zod schemas for tool definitions and Google Gemini's FunctionDeclaration format requirements.
 
-**Compatibility Note**: This mapping applies to both AI SDK v4 and v5-beta. While v5-beta uses `LanguageModelV2` interfaces, the Zod schema conversion process remains the same.
+**Compatibility Note**: This mapping applies to both AI SDK v4 and v5. While v5 uses `LanguageModelV2` interfaces, the Zod schema conversion process remains the same.
 
 ## Core Type Definitions
 
@@ -12,7 +12,7 @@ This document provides a comprehensive mapping between Vercel AI SDK's use of Zo
 
 ```typescript
 // From @ai-sdk/provider
-// Note: In v5-beta this is LanguageModelV2FunctionTool
+// Note: In v5 this is LanguageModelV2FunctionTool
 interface LanguageModelV1FunctionTool {
   type: 'function';
   name: string;

--- a/examples/custom-config.mjs
+++ b/examples/custom-config.mjs
@@ -144,8 +144,8 @@ async function main() {
       }),
     ]);
     
-    console.log('Provider 1:', response1.content[0].text);
-    console.log('Provider 2:', response2.content[0].text);
+    console.log('Provider 1:', response1.content[0]?.text || 'No response generated');
+    console.log('Provider 2:', response2.content[0]?.text || 'No response generated');
     console.log('✅ Multiple instances work independently');
     console.log();
 
@@ -172,7 +172,7 @@ async function main() {
         prompt: `Count to ${i}`,
         maxOutputTokens: 20,
       });
-      responses.push(result.content[0].text);
+      responses.push(result.content[0]?.text || 'No response');
     }
     
     console.log('Responses with persistent settings:');

--- a/examples/integration-test.mjs
+++ b/examples/integration-test.mjs
@@ -48,7 +48,7 @@ async function main() {
       model: gemini('gemini-2.5-pro'),
       prompt: 'Say hello',
     });
-    // In v5-beta, check both .text and .content
+    // In v5, check both .text and .content
     if (!result.text || result.text.length === 0) {
       throw new Error('No text generated');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,28 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-gemini-cli",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-beta.1",
-        "@ai-sdk/provider-utils": "beta",
-        "@google/gemini-cli-core": "^0.1.13",
-        "@google/genai": "^1.7.0",
-        "google-auth-library": "^9.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.3"
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3",
+        "@google/gemini-cli-core": "0.1.21",
+        "@google/genai": "1.14.0",
+        "google-auth-library": "10.2.1",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "3.24.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.10",
         "@vitest/coverage-v8": "^1.6.1",
-        "ai": "^5.0.0-beta.26",
+        "ai": "5.0.14",
         "eslint": "^9.30.0",
         "globals": "^16.2.0",
         "prettier": "^3.3.2",
@@ -40,10 +40,27 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.6.tgz",
+      "integrity": "sha512-JuSj1MtTr4vw2VBBth4wlbciQnQIV0o1YV9qGLFA+r85nR5H+cJp3jaYE0nprqfzC9rYG8w9c6XGHB3SDKgcgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-beta.1.tgz",
-      "integrity": "sha512-Z8SPncMtS3RsoXITmT7NVwrAq6M44dmw0DoUOYJqNNtCu8iMWuxB8Nxsoqpa0uEEy9R1V1ZThJAXTYgjTUxl3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -53,32 +70,21 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.0-canary.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.0-canary.19.tgz",
-      "integrity": "sha512-4IJw6/wkWYLYfFYPvCs5go0L/sBRZsIRW1l/R6LniF4WjAH2+R4dMbESgBmzx+Z2+W+W6gFeK8dnQByn7vaA/w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.3.tgz",
+      "integrity": "sha512-kAxIw1nYmFW1g5TvE54ZB3eNtgZna0RnLjPUp1ltz1+t9xkXJIuDT4atrwfau9IbS0BOef38wqrI8CjFfQrxhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-canary.14",
+        "@ai-sdk/provider": "2.0.0",
         "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.3",
         "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0-canary.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-canary.14.tgz",
-      "integrity": "sha512-aN83hjdjDCyhkOdulwMsxmGb91owS+bCSe6FWg1TEwusNM35vv020nY//Gid/0NdIpVkZJGzAajgCWrnno2zzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "zod": "^3.25.76 || ^4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -798,11 +804,11 @@
       }
     },
     "node_modules/@google/gemini-cli-core": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@google/gemini-cli-core/-/gemini-cli-core-0.1.13.tgz",
-      "integrity": "sha512-Vx3CbRpLJiGs/sj4SXlGH2ALKyON5skV/p+SCAoRuS6yRsANS1+diEeXbp6jlWT2TTiGoa8+GolqeNIU7wbN8w==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@google/gemini-cli-core/-/gemini-cli-core-0.1.21.tgz",
+      "integrity": "sha512-6VwJRATuDniWtBbhKHB9Kc+UC33zYRQTlciVG1mHE7aWxhLlyEfg5xreedQPpMHu3km5KW7HcNOcgT3thsb6uA==",
       "dependencies": {
-        "@google/genai": "1.9.0",
+        "@google/genai": "1.13.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "^0.52.0",
@@ -813,15 +819,21 @@
         "@types/glob": "^8.1.0",
         "@types/html-to-text": "^9.0.4",
         "ajv": "^8.17.1",
+        "chardet": "^2.1.0",
         "diff": "^7.0.0",
         "dotenv": "^17.1.0",
+        "fdir": "^6.4.6",
+        "fzf": "^0.5.2",
         "glob": "^10.4.5",
         "google-auth-library": "^9.11.0",
         "html-to-text": "^9.0.5",
         "https-proxy-agent": "^7.0.6",
         "ignore": "^7.0.0",
+        "marked": "^15.0.12",
         "micromatch": "^4.0.8",
+        "mnemonist": "^0.40.3",
         "open": "^10.1.2",
+        "picomatch": "^4.0.1",
         "shell-quote": "^1.8.3",
         "simple-git": "^3.28.0",
         "strip-ansi": "^7.1.0",
@@ -833,9 +845,9 @@
       }
     },
     "node_modules/@google/gemini-cli-core/node_modules/@google/genai": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.9.0.tgz",
-      "integrity": "sha512-w9P93OXKPMs9H1mfAx9+p3zJqQGrWBGdvK/SVc7cLZEXNHr/3+vW2eif7ZShA6wU24rNLn9z9MK2vQFUvNRI2Q==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.13.0.tgz",
+      "integrity": "sha512-BxilXzE8cJ0zt5/lXk6KwuBcIT9P2Lbi2WXhwWMbxf1RNeC68/8DmYQqMrzQP333CieRMdbDXs0eNCphLoScWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -853,10 +865,128 @@
         }
       }
     },
+    "node_modules/@google/gemini-cli-core/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/gemini-cli-core/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@google/genai": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.11.0.tgz",
-      "integrity": "sha512-4XFAHCvU91ewdWOU3RUdSeXpDuZRJHNYLqT9LKw7WqPjRQcEJvVU+VOU49ocruaSp8VuLKMecl0iadlQK+Zgfw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.14.0.tgz",
+      "integrity": "sha512-jirYprAAJU1svjwSDVCzyVq+FrJpJd5CSxR/g2Ga/gZ0ZYZpcWjMS75KJl9y71K1mDN+tcx6s21CzCbB2R840g==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",
@@ -870,6 +1000,95 @@
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google/genai/node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google/genai/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
           "optional": true
         }
       }
@@ -2572,34 +2791,22 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.0-canary.24",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.0-canary.24.tgz",
-      "integrity": "sha512-vqaMmM6XFwjz9mNjox9ehjkWFwXbSchhor5MiqgKZ1qRyoTvoYzAt6oCZwg5kN5jXNQ3rZVuyE8N3BbPbwma2Q==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.14.tgz",
+      "integrity": "sha512-xiujFa879skB7YxGzbeHAxepsr6AEaWcHPXrc5a9MRM6p4WdVAwn6mGwVZkBnhqGfZtXFr4LUnU2ayvcjWp5ig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0-canary.14",
-        "@ai-sdk/provider-utils": "3.0.0-canary.19",
+        "@ai-sdk/gateway": "1.0.6",
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.3",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/ai/node_modules/@ai-sdk/provider": {
-      "version": "2.0.0-canary.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0-canary.14.tgz",
-      "integrity": "sha512-aN83hjdjDCyhkOdulwMsxmGb91owS+bCSe6FWg1TEwusNM35vv020nY//Gid/0NdIpVkZJGzAajgCWrnno2zzA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "zod": "^3.25.76 || ^4"
       }
     },
     "node_modules/ajv": {
@@ -2878,6 +3085,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -3117,6 +3330,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -3883,6 +4105,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3991,6 +4236,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4040,34 +4297,38 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzf": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -4223,26 +4484,27 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.2.1.tgz",
+      "integrity": "sha512-HMxFl2NfeHYnaL1HoRIN1XgorKS+6CDaM+z9LSSN+i/nKDDL4KFFEWogMXu7jV4HZQy2MsxpY+wA5XIf3w410A==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -4275,16 +4537,16 @@
       "license": "MIT"
     },
     "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "license": "MIT",
       "dependencies": {
-        "gaxios": "^6.0.0",
+        "gaxios": "^7.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/has-flag": {
@@ -5037,6 +5299,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5166,6 +5440,15 @@
         "ufo": "^1.5.4"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
+      "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.4"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -5225,24 +5508,42 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/npm-run-path": {
@@ -5294,6 +5595,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -7565,6 +7872,15 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.1",
   "description": "Community AI SDK provider for Google Gemini using the official CLI/SDK",
   "author": "Ben Vargas",
   "license": "MIT",
@@ -63,20 +63,20 @@
     "examples": "npm run build && npm run example:check && npm run example:basic"
   },
   "dependencies": {
-    "@ai-sdk/provider": "2.0.0-beta.1",
-    "@ai-sdk/provider-utils": "beta",
-    "@google/gemini-cli-core": "^0.1.13",
-    "@google/genai": "^1.7.0",
-    "google-auth-library": "^9.0.0",
-    "zod": "^3.23.8",
-    "zod-to-json-schema": "^3.23.3"
+    "@ai-sdk/provider": "2.0.0",
+    "@ai-sdk/provider-utils": "3.0.3",
+    "@google/gemini-cli-core": "0.1.21",
+    "@google/genai": "1.14.0",
+    "google-auth-library": "10.2.1",
+    "zod": "3.25.76",
+    "zod-to-json-schema": "3.24.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.10",
     "@vitest/coverage-v8": "^1.6.1",
-    "ai": "^5.0.0-beta.26",
+    "ai": "5.0.14",
     "eslint": "^9.30.0",
     "globals": "^16.2.0",
     "prettier": "^3.3.2",
@@ -94,7 +94,6 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public",
-    "tag": "beta"
+    "access": "public"
   }
 }

--- a/src/__tests__/gemini-language-model.test.ts
+++ b/src/__tests__/gemini-language-model.test.ts
@@ -371,7 +371,8 @@ describe('GeminiLanguageModel', () => {
             topP: 0.9,
             maxOutputTokens: 1000,
           }),
-        })
+        }),
+        'ai-sdk-provider'
       );
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,10 @@ export async function initializeGeminiClient(
     authType = AuthType.USE_GEMINI;
   }
 
-  // Create a minimal config object that implements the required methods
+  // Create a config object that will hold the generated config
+  let config: ContentGeneratorConfig;
+  
+  // Create the mock config object with all required methods
   const configMock = {
     getModel: () => modelId,
     getProxy: () =>
@@ -47,10 +50,12 @@ export async function initializeGeminiClient(
       process.env.HTTP_PROXY ||
       process.env.HTTPS_PROXY ||
       undefined,
+    getUsageStatisticsEnabled: () => false,
+    getContentGeneratorConfig: () => config,
   };
 
   // Create the configuration
-  const config = createContentGeneratorConfig(
+  config = createContentGeneratorConfig(
     configMock as Parameters<typeof createContentGeneratorConfig>[0],
     authType
   );

--- a/src/gemini-language-model.ts
+++ b/src/gemini-language-model.ts
@@ -194,7 +194,10 @@ export class GeminiLanguageModel implements LanguageModelV2 {
       // Generate content
       let response;
       try {
-        response = await contentGenerator.generateContent(request);
+        response = await contentGenerator.generateContent(
+          request,
+          'ai-sdk-provider'
+        );
 
         // Check if aborted during generation
         if (options.abortSignal?.aborted) {
@@ -354,7 +357,10 @@ export class GeminiLanguageModel implements LanguageModelV2 {
       // Create streaming response
       let streamResponse;
       try {
-        streamResponse = await contentGenerator.generateContentStream(request);
+        streamResponse = await contentGenerator.generateContentStream(
+          request,
+          'ai-sdk-provider'
+        );
 
         // Check if aborted during stream creation
         if (options.abortSignal?.aborted) {


### PR DESCRIPTION
## Summary
- Bump package version from 1.0.0-beta.1 to 1.0.1 stable
- Update all dependencies to latest stable versions with fixed versioning
- Remove all v5-beta references from documentation

## Changes

### 📦 Dependencies Updated
All dependencies now use fixed versioning for stability as a bridge application:

- `@google/gemini-cli-core`: ^0.1.13 → 0.1.21
- `@google/genai`: ^1.7.0 → 1.14.0  
- `google-auth-library`: ^9.0.0 → 10.2.1
- `@ai-sdk/provider`: 2.0.0-beta.1 → 2.0.0 (stable)
- `@ai-sdk/provider-utils`: beta → 3.0.3 (stable)
- `ai` (devDep): ^5.0.0-beta.26 → 5.0.14 (stable)
- `zod`: ^3.23.8 → 3.25.76
- `zod-to-json-schema`: ^3.23.3 → 3.24.6

### 🐛 Compatibility Fixes
- Added missing `userPromptId` parameter to ContentGenerator calls for gemini-cli-core 0.1.21+
- Added missing `getUsageStatisticsEnabled` and `getContentGeneratorConfig` methods to config mock
- Fixed optional chaining in custom-config.mjs example

### 📝 Documentation Updates
- Removed all "v5-beta" references (now just "v5")
- Updated README badges from beta to stable
- Updated NPM publishing strategy:
  - v1.x uses `latest` tag (for AI SDK v5)
  - v0.x uses `ai-sdk-v4` tag (for AI SDK v4)
- Reversed version table order (newest first)

### ✅ Testing
- All 197 unit tests pass
- Integration test: 13/13 tests pass
- Examples tested and working

## Breaking Changes
Requires `@google/gemini-cli-core` 0.1.21+ due to API signature changes (userPromptId parameter).

## Checklist
- [x] Dependencies updated with fixed versioning
- [x] Code updated for compatibility
- [x] Tests pass
- [x] Examples work
- [x] Documentation updated
- [x] Version bumped to 1.0.1