### PR TITLE
feat: add thinkingConfig support for Gemini 3 thinking mode (AI SDK v6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,61 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0-beta.2] - 2025-12-17
+
+### Added
+
+- **thinkingConfig Support**: Port of thinkingConfig from main branch (v1.5.1) for Gemini 3 thinking mode
+  - `thinkingLevel` for Gemini 3 models (`gemini-3-pro-preview`, `gemini-3-flash-preview`)
+    - Supports values: `low`, `medium`, `high`, `minimal`
+    - Case-insensitive string input (`'HIGH'`, `'high'`, `'High'` all work)
+    - Also accepts `ThinkingLevel` enum for type-safe usage
+  - `thinkingBudget` for Gemini 2.5 models (backwards compatible)
+    - Token-based control: `0` (disabled), `512`, `8192`, `-1` (unlimited)
+  - `includeThoughts` option to include reasoning in responses
+
+- **New Exports**:
+  - `ThinkingLevel` enum exported for type-safe thinkingLevel values
+  - `ThinkingConfigInput` type exported for TypeScript users
+
+### Technical Details
+
+- Local `ThinkingLevel` enum matching `@google/genai` v1.34.0 format (workaround until gemini-cli-core upgrades)
+- `normalizeThinkingLevel` helper for case-insensitive string handling
+- Support at both model-level settings and call-time options
+- Call-time thinkingConfig merges with settings (field-by-field override)
+- Invalid call-time thinkingLevel preserves settings value
+- 10 new tests for thinkingConfig functionality
+- Updated index.test.ts to use V3 types
+- All 191 tests passing
+
+### Example Usage
+
+```typescript
+import { createGeminiProvider, ThinkingLevel } from 'ai-sdk-provider-gemini-cli';
+
+const gemini = createGeminiProvider();
+
+// Using string (case-insensitive)
+const result = await generateText({
+  model: gemini('gemini-3-flash-preview'),
+  prompt: 'Solve this complex problem...',
+  thinkingConfig: {
+    thinkingLevel: 'high',
+    includeThoughts: true,
+  },
+});
+
+// Or using enum
+const result = await generateText({
+  model: gemini('gemini-3-flash-preview'),
+  prompt: 'Solve this complex problem...',
+  thinkingConfig: {
+    thinkingLevel: ThinkingLevel.HIGH,
+  },
+});
+```
+
 ## [2.0.0-beta.1] - 2025-12-15
 
 ### BREAKING CHANGES
@@ -470,6 +525,7 @@ This version is compatible with Vercel AI SDK v5. For v4 compatibility, please u
 - Streaming support
 - Basic error handling
 
+[2.0.0-beta.2]: https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/compare/v2.0.0-beta.1...v2.0.0-beta.2
 [2.0.0-beta.1]: https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/compare/v1.5.0...v2.0.0-beta.1
 [1.5.0]: https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/ben-vargas/ai-sdk-provider-gemini-cli/compare/v1.4.0...v1.4.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-gemini-cli",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.0-beta",
-        "@ai-sdk/provider-utils": "^4.0.0-beta",
+        "@ai-sdk/provider": "3.0.0-beta.26",
+        "@ai-sdk/provider-utils": "4.0.0-beta.51",
         "@google/gemini-cli-core": "0.20.0",
         "@google/genai": "1.30.0",
         "google-auth-library": "^9.11.0",
@@ -21,7 +21,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^20.19.26",
         "@vitest/coverage-v8": "^4.0.15",
-        "ai": "^6.0.0-beta",
+        "ai": "6.0.0-beta.156",
         "eslint": "^9.39.1",
         "globals": "^16.5.0",
         "prettier": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Community AI SDK provider for Google Gemini using the official CLI/SDK",
   "author": "Ben Vargas",
   "license": "MIT",

--- a/src/__tests__/gemini-language-model.test.ts
+++ b/src/__tests__/gemini-language-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GeminiLanguageModel } from '../gemini-language-model';
+import { GeminiLanguageModel, ThinkingLevel } from '../gemini-language-model';
 import { initializeGeminiClient } from '../client';
 import { mapPromptToGeminiFormat } from '../message-mapper';
 import type {
@@ -1047,6 +1047,617 @@ describe('GeminiLanguageModel', () => {
           abortSignal: abortController.signal,
         })
       ).rejects.toThrow('Request aborted');
+    });
+  });
+
+  describe('thinkingConfig support', () => {
+    it('should pass thinkingLevel as enum for Gemini 3 models', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Thinking response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const gemini3Model = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {},
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      await gemini3Model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: ThinkingLevel.HIGH,
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should normalize thinkingLevel string to enum (case-insensitive)', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const gemini3Model = new GeminiLanguageModel({
+        modelId: 'gemini-3-pro-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {},
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      // Test lowercase
+      await gemini3Model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+
+      // Reset mock and test mixed case
+      mockClient.generateContent.mockClear();
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      await gemini3Model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'Low',
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.LOW,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should pass thinkingBudget for Gemini 2.5 models', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      await model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingBudget: 8192,
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingBudget: 8192,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should pass includeThoughts boolean', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      await model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingBudget: 4096,
+          includeThoughts: true,
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingBudget: 4096,
+              includeThoughts: true,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should support thinkingConfig in model settings', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      // Create model with thinkingConfig in settings
+      const modelWithThinking = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {
+          thinkingConfig: {
+            thinkingLevel: 'medium',
+          },
+        },
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      await modelWithThinking.doGenerate({
+        prompt: messages,
+      });
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.MEDIUM,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should allow call-time thinkingConfig to override settings', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      // Create model with thinkingConfig in settings
+      const modelWithThinking = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {
+          thinkingConfig: {
+            thinkingLevel: 'low',
+          },
+        },
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      // Call-time config should override settings
+      await modelWithThinking.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      } as any);
+
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should merge call-time thinkingConfig with settings (not replace)', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      // Create model with thinkingLevel in settings
+      const modelWithThinking = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {
+          thinkingConfig: {
+            thinkingLevel: 'high',
+          },
+        },
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      // Call-time adds includeThoughts, should MERGE with settings thinkingLevel
+      await modelWithThinking.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          includeThoughts: true,
+        },
+      } as any);
+
+      // Both thinkingLevel (from settings) and includeThoughts (from call) should be present
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+              includeThoughts: true,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should handle invalid thinkingLevel string gracefully', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      // Invalid thinkingLevel with no settings - thinkingConfig should not be set
+      await model.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'invalid_level',
+        },
+      } as any);
+
+      // Verify thinkingConfig is not set when only invalid values provided
+      const callArgs = mockClient.generateContent.mock.calls[0][0];
+      expect(callArgs.config.thinkingConfig).toBeUndefined();
+    });
+
+    it('should preserve settings thinkingLevel when call-time value is invalid', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      // Create model with valid thinkingLevel in settings
+      const modelWithThinking = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {
+          thinkingConfig: {
+            thinkingLevel: 'high',
+          },
+        },
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      // Call with invalid thinkingLevel (typo) - should fall back to settings
+      await modelWithThinking.doGenerate({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'hihg', // typo
+        },
+      } as any);
+
+      // Should preserve the valid 'high' from settings, not drop it
+      expect(mockClient.generateContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
+    });
+
+    it('should support all thinkingLevel values', async () => {
+      const mockResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'Response' }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 20,
+        },
+      };
+
+      mockClient.generateContent.mockResolvedValue(mockResponse);
+
+      const gemini3Model = new GeminiLanguageModel({
+        modelId: 'gemini-3-flash-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {},
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      const levels = ['low', 'MEDIUM', 'High', 'MINIMAL'];
+      const expectedEnums = [
+        ThinkingLevel.LOW,
+        ThinkingLevel.MEDIUM,
+        ThinkingLevel.HIGH,
+        ThinkingLevel.MINIMAL,
+      ];
+
+      for (let i = 0; i < levels.length; i++) {
+        mockClient.generateContent.mockClear();
+        mockClient.generateContent.mockResolvedValue(mockResponse);
+
+        await gemini3Model.doGenerate({
+          prompt: messages,
+          thinkingConfig: {
+            thinkingLevel: levels[i],
+          },
+        } as any);
+
+        expect(mockClient.generateContent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: expect.objectContaining({
+              thinkingConfig: {
+                thinkingLevel: expectedEnums[i],
+              },
+            }),
+          }),
+          expect.any(String)
+        );
+      }
+    });
+
+    it('should pass thinkingConfig in streaming mode', async () => {
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            candidates: [
+              {
+                content: {
+                  role: 'model',
+                  parts: [{ text: 'Streamed thinking response' }],
+                },
+                finishReason: 'STOP',
+              },
+            ],
+            usageMetadata: {
+              promptTokenCount: 10,
+              candidatesTokenCount: 20,
+            },
+          };
+        },
+      };
+
+      mockClient.generateContentStream.mockResolvedValue(mockStream);
+
+      const gemini3Model = new GeminiLanguageModel({
+        modelId: 'gemini-3-pro-preview',
+        providerOptions: { authType: 'gemini-api-key', apiKey: 'test-key' },
+        settings: {},
+      });
+
+      const messages: LanguageModelV3CallOptions['prompt'] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Test' }],
+        },
+      ];
+
+      const result = await gemini3Model.doStream({
+        prompt: messages,
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      } as any);
+
+      // Consume the stream
+      const reader = result.stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+
+      expect(mockClient.generateContentStream).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            thinkingConfig: {
+              thinkingLevel: ThinkingLevel.HIGH,
+            },
+          }),
+        }),
+        expect.any(String)
+      );
     });
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -51,71 +51,91 @@ describe('index exports', () => {
   });
 
   describe('AI SDK type re-exports', () => {
-    it('should re-export LanguageModelV2 type', () => {
-      type _TestType = index.LanguageModelV2;
+    it('should re-export LanguageModelV3 type', () => {
+      type _TestType = index.LanguageModelV3;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2FunctionTool type', () => {
-      type _TestType = index.LanguageModelV2FunctionTool;
+    it('should re-export LanguageModelV3FunctionTool type', () => {
+      type _TestType = index.LanguageModelV3FunctionTool;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2ToolCall type', () => {
-      type _TestType = index.LanguageModelV2ToolCall;
+    it('should re-export LanguageModelV3ToolCall type', () => {
+      type _TestType = index.LanguageModelV3ToolCall;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2FinishReason type', () => {
-      type _TestType = index.LanguageModelV2FinishReason;
+    it('should re-export LanguageModelV3FinishReason type', () => {
+      type _TestType = index.LanguageModelV3FinishReason;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2CallOptions type', () => {
-      type _TestType = index.LanguageModelV2CallOptions;
+    it('should re-export LanguageModelV3CallOptions type', () => {
+      type _TestType = index.LanguageModelV3CallOptions;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2CallWarning type', () => {
-      type _TestType = index.LanguageModelV2CallWarning;
+    it('should re-export SharedV3Warning type', () => {
+      type _TestType = index.SharedV3Warning;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2StreamPart type', () => {
-      type _TestType = index.LanguageModelV2StreamPart;
+    it('should re-export LanguageModelV3StreamPart type', () => {
+      type _TestType = index.LanguageModelV3StreamPart;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2Content type', () => {
-      type _TestType = index.LanguageModelV2Content;
+    it('should re-export LanguageModelV3Content type', () => {
+      type _TestType = index.LanguageModelV3Content;
       expect(true).toBe(true);
     });
 
-    it('should re-export LanguageModelV2Usage type', () => {
-      type _TestType = index.LanguageModelV2Usage;
+    it('should re-export LanguageModelV3Usage type', () => {
+      type _TestType = index.LanguageModelV3Usage;
       expect(true).toBe(true);
     });
 
-    it('should re-export ProviderV2 type', () => {
-      type _TestType = index.ProviderV2;
+    it('should re-export ProviderV3 type', () => {
+      type _TestType = index.ProviderV3;
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('thinkingConfig exports', () => {
+    it('should export ThinkingLevel enum', () => {
+      expect(index.ThinkingLevel).toBeDefined();
+      expect(index.ThinkingLevel.LOW).toBe('LOW');
+      expect(index.ThinkingLevel.MEDIUM).toBe('MEDIUM');
+      expect(index.ThinkingLevel.HIGH).toBe('HIGH');
+      expect(index.ThinkingLevel.MINIMAL).toBe('MINIMAL');
+    });
+
+    it('should export ThinkingConfigInput type', () => {
+      // TypeScript type exports are compile-time only
+      type _TestType = index.ThinkingConfigInput;
+      // This test passes if TypeScript compilation succeeds
       expect(true).toBe(true);
     });
   });
 
   describe('export completeness', () => {
     it('should export all expected named exports', () => {
-      const expectedExports = [
+      const expectedFunctionExports = [
         'createGeminiProvider',
         'createGeminiCliCoreProvider', // legacy alias
       ];
 
-      const actualExports = Object.keys(index).filter(
+      const actualFunctionExports = Object.keys(index).filter(
         (key) => typeof (index as any)[key] === 'function'
       );
 
-      for (const expectedExport of expectedExports) {
-        expect(actualExports).toContain(expectedExport);
+      for (const expectedExport of expectedFunctionExports) {
+        expect(actualFunctionExports).toContain(expectedExport);
       }
+
+      // Also verify ThinkingLevel enum is exported
+      expect(index.ThinkingLevel).toBeDefined();
     });
 
     it('should not have any default export', () => {

--- a/src/gemini-language-model.ts
+++ b/src/gemini-language-model.ts
@@ -17,6 +17,23 @@ import type {
   GenerateContentParameters,
   GenerateContentConfig,
 } from '@google/genai';
+
+/**
+ * ThinkingLevel enum for Gemini 3 models.
+ * Note: This is defined locally as @google/genai v1.30.0 doesn't export it yet.
+ * Values match the official @google/genai v1.34.0 ThinkingLevel enum format.
+ * Will be replaced with the official enum when gemini-cli-core upgrades.
+ */
+export enum ThinkingLevel {
+  /** Minimizes latency and cost. Best for simple tasks. */
+  LOW = 'LOW',
+  /** Balanced thinking for most tasks. (Gemini 3 Flash only) */
+  MEDIUM = 'MEDIUM',
+  /** Maximizes reasoning depth. May take longer for first token. */
+  HIGH = 'HIGH',
+  /** Matches "no thinking" for most queries. (Gemini 3 Flash only) */
+  MINIMAL = 'MINIMAL',
+}
 import { initializeGeminiClient } from './client';
 import { mapPromptToGeminiFormat } from './message-mapper';
 import { mapGeminiToolConfig, mapToolsToGeminiFormat } from './tool-mapper';
@@ -31,6 +48,48 @@ export interface GeminiLanguageModelOptions {
     logger?: Logger | false;
     verbose?: boolean;
   };
+}
+
+/**
+ * Input interface for thinkingConfig settings.
+ * Supports both Gemini 3 (thinkingLevel) and Gemini 2.5 (thinkingBudget) models.
+ */
+export interface ThinkingConfigInput {
+  /**
+   * Thinking level for Gemini 3 models (gemini-3-pro-preview, gemini-3-flash-preview).
+   * Accepts case-insensitive strings ('high', 'HIGH', 'High') or ThinkingLevel enum.
+   * Valid values: 'low', 'medium', 'high', 'minimal'
+   */
+  thinkingLevel?: string | ThinkingLevel;
+  /**
+   * Token budget for thinking in Gemini 2.5 models.
+   * Common values: 0 (disabled), 512, 8192 (default), -1 (unlimited)
+   */
+  thinkingBudget?: number;
+  /**
+   * Whether to include thinking/reasoning in the response.
+   */
+  includeThoughts?: boolean;
+}
+
+/**
+ * Normalize thinkingLevel string to ThinkingLevel enum (case-insensitive).
+ * Returns undefined for invalid values, allowing the API to handle validation.
+ */
+function normalizeThinkingLevel(level: string): ThinkingLevel | undefined {
+  const normalized = level.toUpperCase();
+  switch (normalized) {
+    case 'LOW':
+      return ThinkingLevel.LOW;
+    case 'MEDIUM':
+      return ThinkingLevel.MEDIUM;
+    case 'HIGH':
+      return ThinkingLevel.HIGH;
+    case 'MINIMAL':
+      return ThinkingLevel.MINIMAL;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -55,13 +114,63 @@ function mapGeminiFinishReason(
 }
 
 /**
- * Prepare generation config with proper handling for JSON mode.
+ * Extended ThinkingConfig type that includes thinkingLevel (not yet in @google/genai v1.30.0 types).
+ * This is a temporary workaround until the official types are updated.
+ * Using Omit to remove any existing thinkingLevel type and replace with our enum.
+ */
+type ExtendedThinkingConfig = Omit<
+  NonNullable<GenerateContentConfig['thinkingConfig']>,
+  'thinkingLevel'
+> & {
+  thinkingLevel?: ThinkingLevel;
+};
+
+/**
+ * Build thinkingConfig from user input, normalizing string thinkingLevel to enum.
+ */
+function buildThinkingConfig(
+  input: ThinkingConfigInput
+): ExtendedThinkingConfig {
+  const config = {} as ExtendedThinkingConfig;
+
+  // Handle thinkingLevel (string or enum)
+  if (input.thinkingLevel !== undefined) {
+    if (typeof input.thinkingLevel === 'string') {
+      const normalized = normalizeThinkingLevel(input.thinkingLevel);
+      if (normalized !== undefined) {
+        config.thinkingLevel = normalized;
+      }
+      // If normalization fails, we skip setting thinkingLevel
+      // and let the API handle any validation errors
+    } else {
+      // Already a ThinkingLevel enum value
+      config.thinkingLevel = input.thinkingLevel;
+    }
+  }
+
+  // Handle thinkingBudget (number)
+  if (input.thinkingBudget !== undefined) {
+    config.thinkingBudget = input.thinkingBudget;
+  }
+
+  // Handle includeThoughts (boolean)
+  if (input.includeThoughts !== undefined) {
+    config.includeThoughts = input.includeThoughts;
+  }
+
+  return config;
+}
+
+/**
+ * Prepare generation config with proper handling for JSON mode and thinkingConfig.
  *
  * When JSON response format is requested WITHOUT a schema, we downgrade to
  * text/plain and emit a warning. This aligns with Claude-code provider behavior
  * and prevents raw fenced JSON from leaking to clients.
  *
  * When a schema IS provided, we use native responseJsonSchema for structured output.
+ *
+ * ThinkingConfig supports both Gemini 3 (thinkingLevel) and Gemini 2.5 (thinkingBudget).
  */
 function prepareGenerationConfig(
   options: LanguageModelV3CallOptions,
@@ -88,6 +197,42 @@ function prepareGenerationConfig(
     });
   }
 
+  // Handle thinkingConfig from options (call-time) and settings (model-level)
+  // Merge fields: call-time options override settings per-field (like temperature/topP)
+  // Special handling for thinkingLevel: invalid call-time values fall back to settings
+  const settingsThinkingConfig = settings?.thinkingConfig as
+    | ThinkingConfigInput
+    | undefined;
+  const optionsThinkingConfig = (options as Record<string, unknown>)
+    .thinkingConfig as ThinkingConfigInput | undefined;
+
+  // Validate call-time thinkingLevel before merging
+  // If invalid, preserve settings thinkingLevel instead of silently dropping it
+  let effectiveOptionsThinking = optionsThinkingConfig;
+  if (
+    optionsThinkingConfig?.thinkingLevel !== undefined &&
+    typeof optionsThinkingConfig.thinkingLevel === 'string'
+  ) {
+    const normalized = normalizeThinkingLevel(
+      optionsThinkingConfig.thinkingLevel
+    );
+    if (normalized === undefined) {
+      // Invalid thinkingLevel - remove it so settings value is preserved
+      const { thinkingLevel: _, ...rest } = optionsThinkingConfig;
+      effectiveOptionsThinking =
+        Object.keys(rest).length > 0 ? rest : undefined;
+    }
+  }
+
+  const mergedThinkingConfig =
+    settingsThinkingConfig || effectiveOptionsThinking
+      ? { ...settingsThinkingConfig, ...effectiveOptionsThinking }
+      : undefined;
+
+  const thinkingConfig = mergedThinkingConfig
+    ? buildThinkingConfig(mergedThinkingConfig)
+    : undefined;
+
   const generationConfig: GenerateContentConfig = {
     temperature:
       options.temperature ?? (settings?.temperature as number | undefined),
@@ -102,6 +247,9 @@ function prepareGenerationConfig(
     // Pass schema directly to Gemini API for native structured output
     responseJsonSchema: hasSchema ? schema : undefined,
     toolConfig: mapGeminiToolConfig(options),
+    // Pass thinkingConfig for Gemini 3 (thinkingLevel) or Gemini 2.5 (thinkingBudget)
+    // Cast needed because our ThinkingLevel enum isn't recognized by @google/genai v1.30.0 types
+    thinkingConfig: thinkingConfig as GenerateContentConfig['thinkingConfig'],
   };
 
   return { generationConfig, warnings };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
 // Main exports
 export { createGeminiProvider } from './gemini-provider';
 
+// Export ThinkingLevel enum for users who prefer enum over string
+export { ThinkingLevel } from './gemini-language-model';
+
 // Type exports
 export type { GeminiProvider } from './gemini-provider';
 export type { GeminiProviderOptions, Logger } from './types';
+export type { ThinkingConfigInput } from './gemini-language-model';
 
 // Legacy compatibility exports (for backward compatibility)
 export { createGeminiProvider as createGeminiCliCoreProvider } from './gemini-provider';


### PR DESCRIPTION
## Summary

Port thinkingConfig support from main branch (v1.5.1) to AI SDK v6, enabling Gemini 3 thinking/reasoning mode.

### Features
- **thinkingLevel** for Gemini 3 models (`gemini-3-pro-preview`, `gemini-3-flash-preview`)
  - Supports values: `low`, `medium`, `high`, `minimal`
  - Case-insensitive string input (`'HIGH'`, `'high'`, `'High'` all work)
  - Also accepts `ThinkingLevel` enum for type-safe usage
- **thinkingBudget** for Gemini 2.5 models (backwards compatible)
  - Token-based control: `0` (disabled), `512`, `8192`, `-1` (unlimited)
- **includeThoughts** option to include reasoning in responses

### Implementation
- Local `ThinkingLevel` enum matching `@google/genai` v1.34.0 format
- `ThinkingConfigInput` type exported for users
- `normalizeThinkingLevel` helper for case-insensitive string handling
- Support at both model-level settings and call-time options
- Call-time thinkingConfig merges with settings (not replaces)
- Invalid call-time thinkingLevel preserves settings value

### Usage Example
```typescript
import { createGeminiProvider, ThinkingLevel } from 'ai-sdk-provider-gemini-cli';

const gemini = createGeminiProvider();

// Using string (case-insensitive)
const result = await generateText({
  model: gemini('gemini-3-flash-preview'),
  prompt: 'Solve this complex problem...',
  thinkingConfig: {
    thinkingLevel: 'high',
    includeThoughts: true,
  },
});

// Or using enum
const result = await generateText({
  model: gemini('gemini-3-flash-preview'),
  prompt: 'Solve this complex problem...',
  thinkingConfig: {
    thinkingLevel: ThinkingLevel.HIGH,
  },
});
```

## Test plan
- [x] All 191 unit tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] All 13 integration tests pass (`node examples/integration-test.mjs`)
- [x] Verified all example files work correctly