### PR TITLE
Fix tool schema default object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2026-01-02
+
+### Fixed
+
+- Default function tool parameter schemas to `type: "object"` when only `properties` are provided (fixes Gemini function declaration validation error).
+
 ## [2.0.0] - 2025-12-28
 
 ### BREAKING CHANGES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-gemini-cli",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-gemini-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Community AI SDK provider for Google Gemini using the official CLI/SDK",
   "author": "Ben Vargas",
   "license": "MIT",

--- a/src/__tests__/tool-mapper.test.ts
+++ b/src/__tests__/tool-mapper.test.ts
@@ -108,6 +108,32 @@ describe('mapToolsToGeminiFormat', () => {
       });
     });
 
+    it('should default type to object when properties are provided', () => {
+      const tools: LanguageModelV2FunctionTool[] = [
+        {
+          type: 'function',
+          name: 'getWeather',
+          description: 'Get the weather for a location',
+          inputSchema: {
+            properties: {
+              location: { type: 'string' },
+            },
+            required: ['location'],
+          },
+        },
+      ];
+
+      const result = mapToolsToGeminiFormat(tools);
+
+      expect(result[0].functionDeclarations[0].parameters).toEqual({
+        type: 'object',
+        properties: {
+          location: { type: 'string' },
+        },
+        required: ['location'],
+      });
+    });
+
     it('should clean $schema from JSON schema', () => {
       const tools: LanguageModelV2FunctionTool[] = [
         {

--- a/src/tool-mapper.ts
+++ b/src/tool-mapper.ts
@@ -180,6 +180,10 @@ function cleanJsonSchema(schema: JsonSchemaObject): JsonSchemaObject {
     }
   }
 
+  if (cleaned.properties && cleaned.type === undefined) {
+    cleaned.type = 'object';
+  }
+
   return cleaned;
 }
 


### PR DESCRIPTION
## Summary
- Default tool parameter schemas to `type: "object"` when only `properties` are provided
- Add regression coverage for object schema defaults
- Bump version to 2.0.1 and update changelog

## Testing
- npm run type-check
- npm run format:check
- npm run lint
- npm test

## Context
- Fixes #34
