### PR TITLE
docs: add missing tool calling example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ See the [examples/](examples/) directory for comprehensive examples:
 npm run build
 npm run example:check
 npm run example:basic
+npm run example:tool
 ```
 
 ## Breaking Changes

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,15 @@ node examples/conversation-history.mjs
 ```
 **Key concepts**: Message history, context preservation, multi-turn conversations
 
+## Tool Calling
+
+### Tool Calling (`tool-calling.mjs`)
+**Purpose**: Expose a local function to Gemini and use the tool result in a final answer.
+```bash
+node examples/tool-calling.mjs
+```
+**Key concepts**: Tool schemas, `tool()` helper, multi-step generation, tool results
+
 ## Logging Examples
 
 The provider includes a flexible logging system that can be configured for different use cases. These examples demonstrate all logging modes:

--- a/examples/tool-calling.mjs
+++ b/examples/tool-calling.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Tool Calling Example
+ *
+ * This example demonstrates how to expose a local tool to Gemini through the
+ * Vercel AI SDK and let the model use the tool result in its final answer.
+ */
+
+import { generateText, stepCountIs, tool } from 'ai';
+import { z } from 'zod';
+import { createGeminiProvider } from '../dist/index.mjs';
+
+console.log('Gemini CLI Provider - Tool Calling Example\n');
+
+const weatherByLocation = {
+  santiago: {
+    location: 'Santiago, Chile',
+    condition: 'clear',
+    temperatureC: 14,
+    windKph: 8,
+  },
+  london: {
+    location: 'London, UK',
+    condition: 'rain',
+    temperatureC: 11,
+    windKph: 18,
+  },
+  tokyo: {
+    location: 'Tokyo, Japan',
+    condition: 'humid',
+    temperatureC: 24,
+    windKph: 6,
+  },
+};
+
+async function main() {
+  try {
+    const gemini = createGeminiProvider({
+      authType: 'oauth-personal',
+    });
+
+    const result = await generateText({
+      model: gemini('gemini-3-flash-preview'),
+      prompt:
+        'Use the getWeather tool to check Santiago, then tell me whether I should bring a jacket.',
+      tools: {
+        getWeather: tool({
+          description: 'Get the current weather for a supported city.',
+          inputSchema: z.object({
+            location: z
+              .string()
+              .describe('City name, for example Santiago, London, or Tokyo'),
+          }),
+          execute: async ({ location }) => {
+            const key = location.toLowerCase().split(',')[0].trim();
+            return (
+              weatherByLocation[key] ?? {
+                location,
+                condition: 'unknown',
+                temperatureC: 18,
+                windKph: 10,
+              }
+            );
+          },
+        }),
+      },
+      stopWhen: stepCountIs(2),
+    });
+
+    console.log('Final answer:');
+    console.log(result.text || 'No final text generated');
+
+    console.log('\nTool calls:');
+    for (const call of result.toolCalls) {
+      console.log(`- ${call.toolName}: ${JSON.stringify(call.input)}`);
+    }
+
+    console.log('\nTool results:');
+    for (const toolResult of result.toolResults) {
+      console.log(
+        `- ${toolResult.toolName}: ${JSON.stringify(toolResult.output)}`
+      );
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+    console.log('\nTips:');
+    console.log('- Build the provider first: npm run build');
+    console.log('- Authenticate with Gemini CLI: gemini');
+    console.log('- Verify authentication: node examples/check-auth.mjs');
+  }
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "example:basic": "node examples/basic-usage.mjs",
     "example:stream": "node examples/streaming.mjs",
     "example:conversation": "node examples/conversation-history.mjs",
+    "example:tool": "node examples/tool-calling.mjs",
     "example:object": "node examples/generate-object-basic.mjs",
     "example:pdf": "node examples/pdf-document-analysis.mjs",
     "example:test": "node examples/integration-test.mjs",


### PR DESCRIPTION
## Summary

- add the documented `examples/tool-calling.mjs` example
- wire `npm run example:tool`
- add the example to the examples index

## Validation

- `node --check examples/tool-calling.mjs`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test`

Note: I did not run the live example because it requires local Gemini CLI authentication. I also observed that `npm run format:check` reports existing formatting issues in `src/gemini-language-model.ts` and `src/message-mapper.ts`, which this PR does not touch.
